### PR TITLE
Show Core 1.0 alt art option for Revised Core Set cards.

### DIFF
--- a/data/promo.json
+++ b/data/promo.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "core",
+    "name": "Core 1.0",
+    "cards": []
+  },
+  {
     "version": "alt",
     "name": "Alternate",
     "cards":

--- a/src/cljs/netrunner/account.cljs
+++ b/src/cljs/netrunner/account.cljs
@@ -21,6 +21,11 @@
                                   (contains? % :replaced_by))
                             (update % :title (fn [t] (str t " (" (:setname %) ")")))
                             %))
+                   (map #(let [replaces (:replaces %)
+                               setname (:setname %)]
+                           (if (and replaces (= "Revised Core Set" setname))
+                             (update-in % [:alt_art] assoc :core replaces)
+                             %)))
                     (into {} (map (juxt :code identity))))]
         (swap! app-state assoc :alt-arts cards)
         (swap! app-state assoc :alt-info alt_info)


### PR DESCRIPTION
Adds a dummy alt art category to the promo.json file. For any card in the Revised Core Set that replaces another card, adds a Core 1.0 art option to the alt art editor.

This should probably wait until we have art for the Revised cards, otherwise you just get duplicate artwork entries.