### PR TITLE
Link alt art selection for replaced cards.

### DIFF
--- a/src/cljs/netrunner/account.cljs
+++ b/src/cljs/netrunner/account.cljs
@@ -15,12 +15,8 @@
                        (:json)
                        (map #(select-keys % [:version :name])))
             cards (->> (:cards @app-state)
-                    (filter :alt_art)
+                    (filter #(and (:alt_art %) (not (:replaced_by %))))
                     (map #(select-keys % [:title :setname :code :alt_art :replaces :replaced_by]))
-                    (map #(if (or (contains? % :replaces)
-                                  (contains? % :replaced_by))
-                            (update % :title (fn [t] (str t " (" (:setname %) ")")))
-                            %))
                     (into {} (map (juxt :code identity))))]
         (swap! app-state assoc :alt-arts cards)
         (swap! app-state assoc :alt-info alt_info)
@@ -94,8 +90,15 @@
 (defn set-card-art
   [owner value]
   (om/set-state! owner :alt-card-version value)
-  (om/update-state! owner [:alt-arts]
-                    (fn [m] (assoc m (keyword (om/get-state owner :alt-card)) value))))
+
+  (let [code (om/get-state owner :alt-card)
+        card (some #(when (= code (:code %)) %) (:cards @app-state))]
+    (om/update-state! owner [:alt-arts]
+                      (fn [m]
+                        (if-let [replaces (:replaces card)]
+                          (assoc m (keyword code) value
+                                   (keyword replaces) value)
+                          (assoc m (keyword code) value))))))
 
 (defn reset-card-art
   [owner]


### PR DESCRIPTION
Removes the separate entries for Core Set vs Revised Core Set cards in the alt art editor (by removing any card with `:replaced_by`). Selecting art for the Revised Core Set card also sets the art for the replaced card.